### PR TITLE
Add support of Microchip AT24C32 and support of single chip for `EEPR…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ In the table below the Interface column includes page size in bytes.
 | Microchip    | 24xx256   | I2C 128   |  32KiB  |   EEPROM   | [I2C.md](./eeprom/i2c/I2C.md) |
 | Microchip    | 24xx128   | I2C 128   |  16KiB  |   EEPROM   | [I2C.md](./eeprom/i2c/I2C.md) |
 | Microchip    | 24xx64    | I2C 128   |   8KiB  |   EEPROM   | [I2C.md](./eeprom/i2c/I2C.md) |
+| Microchip    | 24xx32    | I2C 32    |   4KiB  |   EEPROM   | [I2C.md](./eeprom/i2c/I2C.md) |
 | Adafruit     | 4719      | SPI n/a   | 512KiB  |   FRAM     | [FRAM_SPI.md](./fram/FRAM_SPI.md) |
 | Adafruit     | 4718      | SPI n/a   | 256KiB  |   FRAM     | [FRAM_SPI.md](./fram/FRAM_SPI.md) |
 | Adafruit     | 1895      | I2C n/a   |  32KiB  |   FRAM     | [FRAM.md](./fram/FRAM.md)     |

--- a/eeprom/i2c/I2C.md
+++ b/eeprom/i2c/I2C.md
@@ -124,7 +124,8 @@ is detected or if device address lines are not wired as described in
 Arguments:  
  1. `i2c` Mandatory. An initialised master mode I2C bus created by `machine`.
  2. `chip_size=T24C512` The chip size in bits. The module provides constants
- `T24C64`, `T24C128`, `T24C256`, `T24C512` for the supported chip sizes.
+ `T24C32`, `T24C64`, `T24C128`, `T24C256`, `T24C512` for the supported 
+chip sizes.
  3. `verbose=True` If `True`, the constructor issues information on the EEPROM
  devices it has detected.
  4. `block_size=9` The block size reported to the filesystem. The size in bytes

--- a/eeprom/i2c/eep_i2c.py
+++ b/eeprom/i2c/eep_i2c.py
@@ -57,8 +57,10 @@ def _testblock(eep, bs):
     if res != d2:
         return 'Block test fail 3:' + str(list(res))
 
-def test():
-    eep = get_eep()
+
+def test(eep=None):
+    eep = eep if eep else get_eep()
+
     sa = 1000
     for v in range(256):
         eep[sa + v] = v
@@ -93,8 +95,8 @@ def test():
         print('Test chip boundary skipped: only one chip!')
 
 # ***** TEST OF FILESYSTEM MOUNT *****
-def fstest(format=False):
-    eep = get_eep()
+def fstest(eep=None, format=False):
+    eep = eep if eep else get_eep()
     try:
         uos.umount('/eeprom')
     except OSError:
@@ -114,8 +116,10 @@ def fstest(format=False):
     print('Contents of "/eeprom": {}'.format(uos.listdir('/eeprom')))
     print(uos.statvfs('/eeprom'))
 
-def cptest():  # Assumes pre-existing filesystem of either type
-    eep = get_eep()
+
+def cptest(eep=None):  # Assumes pre-existing filesystem of either type
+    eep = eep if eep else get_eep()
+
     if 'eeprom' in uos.listdir('/'):
         print('Device already mounted.')
     else:
@@ -131,13 +135,13 @@ def cptest():  # Assumes pre-existing filesystem of either type
     print(uos.statvfs('/eeprom'))
 
 # ***** TEST OF HARDWARE *****
-def full_test():
-    eep = get_eep()
+def full_test(eep=None, block_size = 128):
+    eep = eep if eep else get_eep()
     page = 0
-    for sa in range(0, len(eep), 128):
-        data = uos.urandom(128)
-        eep[sa:sa + 128] = data
-        if eep[sa:sa + 128] == data:
+    for sa in range(0, len(eep), block_size):
+        data = uos.urandom(block_size)
+        eep[sa:sa + block_size] = data
+        if eep[sa:sa + block_size] == data:
             print('Page {} passed'.format(page))
         else:
             print('Page {} readback failed.'.format(page))

--- a/eeprom/i2c/eeprom_i2c.py
+++ b/eeprom/i2c/eeprom_i2c.py
@@ -8,22 +8,26 @@ from micropython import const
 from bdevice import BlockDevice
 
 _ADDR = const(0x50)  # Base address of chip
+_MAX_CHIPS_COUNT = const(8)  # Max number of chips
 
 T24C512 = const(65536)  # 64KiB 512Kbits
 T24C256 = const(32768)  # 32KiB 256Kbits
 T24C128 = const(16384)  # 16KiB 128Kbits
 T24C64 = const(8192)  # 8KiB 64Kbits
+T24C32 = const(4096)  # 4KiB 32Kbits
 
 # Logical EEPROM device consists of 1-8 physical chips. Chips must all be the
-# same size, and must have contiguous addresses starting from 0x50.
+# same size, and must have contiguous addresses.
 class EEPROM(BlockDevice):
 
     def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9):
         self._i2c = i2c
-        if chip_size not in (T24C64, T24C128, T24C256, T24C512):
+        if chip_size not in (T24C64, T24C128, T24C256, T24C512, T24C32):
             print('Warning: possible unsupported chip. Size:', chip_size)
-        nchips = self.scan(verbose, chip_size)  # No. of EEPROM chips
+        nchips, min_chip_address = self.scan(verbose, chip_size)  # No. of EEPROM chips
         super().__init__(block_size, nchips, chip_size)
+
+        self._min_chip_address = min_chip_address
         self._i2c_addr = 0  # I2C address of current chip
         self._buf1 = bytearray(1)
         self._addrbuf = bytearray(2)  # Memory offset into current chip
@@ -31,16 +35,23 @@ class EEPROM(BlockDevice):
     # Check for a valid hardware configuration
     def scan(self, verbose, chip_size):
         devices = self._i2c.scan()  # All devices on I2C bus
-        eeproms = [d for d in devices if _ADDR <= d < _ADDR + 8]  # EEPROM chips
+        eeproms = [d for d in devices if _ADDR <= d < _ADDR + _MAX_CHIPS_COUNT]  # EEPROM chips
         nchips = len(eeproms)
         if nchips == 0:
             raise RuntimeError('EEPROM not found.')
-        if min(eeproms) != _ADDR or (max(eeproms) - _ADDR) >= nchips:
+
+        eeproms = sorted(eeproms)
+        if len(set(eeproms)) != len(eeproms):
+            raise RuntimeError('Duplicate addresses were found', eeproms)
+
+        if (eeproms[-1] - eeproms[0] + 1) != len(eeproms):
             raise RuntimeError('Non-contiguous chip addresses', eeproms)
+
         if verbose:
             s = '{} chips detected. Total EEPROM size {}bytes.'
             print(s.format(nchips, chip_size * nchips))
-        return nchips
+
+        return nchips, min(eeproms)
 
     def _wait_rdy(self):  # After a write, wait for device to become ready
         self._buf1[0] = 0
@@ -61,7 +72,7 @@ class EEPROM(BlockDevice):
         ca, la = divmod(addr, self._c_bytes)  # ca == chip no, la == offset into chip
         self._addrbuf[0] = (la >> 8) & 0xff
         self._addrbuf[1] = la & 0xff
-        self._i2c_addr = _ADDR + ca
+        self._i2c_addr = self._min_chip_address + ca
         pe = (addr & ~0x7f) + 0x80  # byte 0 of next page
         return min(nbytes, pe - la)
 


### PR DESCRIPTION
Add support of Microchip AT24C32 and support of single chip for `EEPROM` class

[Description]

Adds support of:

1. Microchip AT24C32 (4 KiB)
2. Support of single chip setup for `EEPROM` class when single chip has address is 0x57 so entire set of chips (1 chip in our case) addresses are not started from 0x50.

Example:

```python
from eeprom_i2c import EEPROM, T24C32

eeprom = PROM(machine.I2C(0), T24C32)
```

Improves tests implementation by adding dependency injection of `EEPROM` object used during testing with support of old use case when object had not been provided for testing.

Example (for AT24C32 connected to I2C0 of my Raspberry Pi Pico W) when we creating instance of `EEPROM` and then passing it to `full_test` and also providing proper block size for this chip:

```python
import machine
from eeprom_i2c import EEPROM, T24C32
from eep_i2c import full_test

def get_eep():
    return EEPROM(machine.I2C(0), T24C32)

def main():
    print("App started")

    print("Running tests")
    eep = get_eep()
    full_test(eep, block_size=32)
    print("App finished")

if __name__ == "__main__":
    main()
```

[Motivation]

Have DS3231 with soldered AT24C32 chip and want to use both RTC and EEPROM. In my case AT24C32 has 0x57 as it's address and `EEPROM` class refused to work with this setup.

[Testing]

Executed `full_test` from `eep_i2c` against AT24C32 (with address 0x57) connected to my Raspberry Pi Pico W.

Test code:

```python
import machine
from eeprom_i2c import EEPROM, T24C32
from eep_i2c import full_test

def get_eep():
    return EEPROM(machine.I2C(0), T24C32)

def main():
    print("App started")

    print("Running tests")
    eep = get_eep()
    full_test(eep, block_size=32)
    print("App finished")

if __name__ == "__main__":
    main()
```