### PR TITLE
Update eeprom_i2c.py

### DIFF
--- a/eeprom/i2c/I2C.md
+++ b/eeprom/i2c/I2C.md
@@ -131,8 +131,25 @@ Arguments:
  4. `block_size=9` The block size reported to the filesystem. The size in bytes
  is `2**block_size` so is 512 bytes by default.
  5. `addr` override base address for first chip
- 6. 'max_chips_count` override max_chips_count
+ 6. `max_chips_count` override max_chips_count
 
+ With `addr` and `max_chips_count` override, it's possible to make multiple
+ configuration
+ 
+ example:
+ array with custom chips count:
+ ```python
+ eeprom0 = EEPROM( i2c, max_chips_count=2 ) 
+ eeprom1 = EEPROM( i2c, addr=0x52, max_chips_count=2 )
+ ```
+ 1st array using address 0x50 and 0x51 and 2nd using array address 0x52 and 0x53.
+
+ individual chip usage:
+ ```python
+ eeprom0 = EEPROM( i2c, addr=0x50, max_chips_count=1 )
+ eeprom1 = EEPROM( i2c, addr=0x51, max_chips_count=1 )
+ ```
+ 
 ### 4.1.2 Methods providing byte level access
 
 It is possible to read and write individual bytes or arrays of arbitrary size.

--- a/eeprom/i2c/I2C.md
+++ b/eeprom/i2c/I2C.md
@@ -130,6 +130,8 @@ Arguments:
  devices it has detected.
  4. `block_size=9` The block size reported to the filesystem. The size in bytes
  is `2**block_size` so is 512 bytes by default.
+ 5. `addr` override base address for first chip
+ 6. 'max_chips_count` override max_chips_count
 
 ### 4.1.2 Methods providing byte level access
 

--- a/eeprom/i2c/I2C.md
+++ b/eeprom/i2c/I2C.md
@@ -137,6 +137,7 @@ Arguments:
  configuration
  
  example:
+ 
  array with custom chips count:
  ```python
  eeprom0 = EEPROM( i2c, max_chips_count=2 ) 

--- a/eeprom/i2c/eeprom_i2c.py
+++ b/eeprom/i2c/eeprom_i2c.py
@@ -23,7 +23,7 @@ class EEPROM(BlockDevice):
         self._i2c = i2c
         if chip_size not in (T24C32, T24C64, T24C128, T24C256, T24C512):
             print("Warning: possible unsupported chip. Size:", chip_size)
-        nchips, min_chip_address = self.scan(verbose, chip_size)  # No. of EEPROM chips
+        nchips, min_chip_address = self.scan(verbose, chip_size, addr, max_chips_count)  # No. of EEPROM chips
         super().__init__(block_size, nchips, chip_size)
         self._min_chip_address = min_chip_address
         self._i2c_addr = 0  # I2C address of current chip

--- a/eeprom/i2c/eeprom_i2c.py
+++ b/eeprom/i2c/eeprom_i2c.py
@@ -19,7 +19,7 @@ T24C32 = const(4096)  # 4KiB 32Kbits
 # Logical EEPROM device consists of 1-8 physical chips. Chips must all be the
 # same size, and must have contiguous addresses.
 class EEPROM(BlockDevice):
-    def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9):
+    def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9, addr=_ADDR, max_chips_count=_MAX_CHIPS_COUNT):
         self._i2c = i2c
         if chip_size not in (T24C32, T24C64, T24C128, T24C256, T24C512):
             print("Warning: possible unsupported chip. Size:", chip_size)
@@ -31,9 +31,9 @@ class EEPROM(BlockDevice):
         self._addrbuf = bytearray(2)  # Memory offset into current chip
 
     # Check for a valid hardware configuration
-    def scan(self, verbose, chip_size):
+    def scan(self, verbose, chip_size, addr, max_chips_count):
         devices = self._i2c.scan()  # All devices on I2C bus
-        eeproms = [d for d in devices if _ADDR <= d < _ADDR + _MAX_CHIPS_COUNT]  # EEPROM chips
+        eeproms = [d for d in devices if addr <= d < addr + max_chips_count]  # EEPROM chips
         nchips = len(eeproms)
         if nchips == 0:
             raise RuntimeError("EEPROM not found.")


### PR DESCRIPTION
allow to override addr and max_chips_count

there is PCF8563T rtc chip onboard  xiao expansion board that use 0x51 address that have conflicted with i2c_eeprom scan address.