### PR TITLE
Add support for I2C EEPROMs with page sizes other than 128 in eeprom_…

### DIFF
--- a/eeprom/i2c/I2C.md
+++ b/eeprom/i2c/I2C.md
@@ -132,6 +132,7 @@ Arguments:
  is `2**block_size` so is 512 bytes by default.
  5. `addr` override base address for first chip
  6. `max_chips_count` override max_chips_count
+ 7. `page_size=7` The binary logarithm of the page size of the EEPROMs, i.e., the page size in bytes is `2 ** page_size`. The page size may vary between chips from different manufacturers even for the same storage size. Note that specifying a too large value will most likely lead to data corruption in write operations. Look up the correct value for your setup in the chip's datasheet.
 
  With `addr` and `max_chips_count` override, it's possible to make multiple
  configuration

--- a/eeprom/i2c/eep_i2c.py
+++ b/eeprom/i2c/eep_i2c.py
@@ -132,8 +132,10 @@ def cptest(eep=None):  # Assumes pre-existing filesystem of either type
             print("Fail mounting device. Have you formatted it?")
             return
         print("Mounted device.")
-    cp("eep_i2c.py", "/eeprom/")
-    cp("eeprom_i2c.py", "/eeprom/")
+    cp(__file__, "/eeprom/")
+    # We may have the source file or a precompiled binary (*.mpy)
+    suffix = __file__[__file__.rfind('.'):]
+    cp("eeprom_i2c" + suffix, "/eeprom/")
     print('Contents of "/eeprom": {}'.format(uos.listdir("/eeprom")))
     print(uos.statvfs("/eeprom"))
 

--- a/eeprom/i2c/eeprom_i2c.py
+++ b/eeprom/i2c/eeprom_i2c.py
@@ -16,10 +16,18 @@ T24C128 = const(16384)  # 16KiB 128Kbits
 T24C64 = const(8192)  # 8KiB 64Kbits
 T24C32 = const(4096)  # 4KiB 32Kbits
 
+_PAGE_SIZES = {
+    T24C32: const(0x20),
+    T24C64: const(0x20),
+    T24C128: const(0x40),
+    T24C256: const(0x40),
+    T24C512: const(0x80),
+    }
+
 # Logical EEPROM device consists of 1-8 physical chips. Chips must all be the
 # same size, and must have contiguous addresses.
 class EEPROM(BlockDevice):
-    def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9, addr=_ADDR, max_chips_count=_MAX_CHIPS_COUNT):
+    def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9, addr=_ADDR, max_chips_count=_MAX_CHIPS_COUNT, page_size=None):
         self._i2c = i2c
         if chip_size not in (T24C32, T24C64, T24C128, T24C256, T24C512):
             print("Warning: possible unsupported chip. Size:", chip_size)
@@ -29,6 +37,16 @@ class EEPROM(BlockDevice):
         self._i2c_addr = 0  # I2C address of current chip
         self._buf1 = bytearray(1)
         self._addrbuf = bytearray(2)  # Memory offset into current chip
+        if page_size is None:
+            if chip_size not in _PAGE_SIZES:
+                raise ValueError(
+                    f'The page size for chip size {chip_size} is not known.'
+                    'Please specify it in the parameter page_size')
+            self._page_mask = ~(_PAGE_SIZES[chip_size] - 1)
+            self._page_size = _PAGE_SIZES[chip_size]
+        else:
+            self._page_mask = ~(page_size - 1)
+            self._page_size = page_size
 
     # Check for a valid hardware configuration
     def scan(self, verbose, chip_size, addr, max_chips_count):
@@ -67,7 +85,7 @@ class EEPROM(BlockDevice):
         self._addrbuf[0] = (la >> 8) & 0xFF
         self._addrbuf[1] = la & 0xFF
         self._i2c_addr = self._min_chip_address + ca
-        pe = (addr & ~0x7F) + 0x80  # byte 0 of next page
+        pe = (addr & self._page_mask) + self._page_size  # byte 0 of next page
         return min(nbytes, pe - la)
 
     # Read or write multiple bytes at an arbitrary address

--- a/eeprom/i2c/eeprom_i2c.py
+++ b/eeprom/i2c/eeprom_i2c.py
@@ -16,18 +16,10 @@ T24C128 = const(16384)  # 16KiB 128Kbits
 T24C64 = const(8192)  # 8KiB 64Kbits
 T24C32 = const(4096)  # 4KiB 32Kbits
 
-_PAGE_SIZES = {
-    T24C32: const(0x20),
-    T24C64: const(0x20),
-    T24C128: const(0x40),
-    T24C256: const(0x40),
-    T24C512: const(0x80),
-    }
-
 # Logical EEPROM device consists of 1-8 physical chips. Chips must all be the
 # same size, and must have contiguous addresses.
 class EEPROM(BlockDevice):
-    def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9, addr=_ADDR, max_chips_count=_MAX_CHIPS_COUNT, page_size=None):
+    def __init__(self, i2c, chip_size=T24C512, verbose=True, block_size=9, addr=_ADDR, max_chips_count=_MAX_CHIPS_COUNT, page_size=7):
         self._i2c = i2c
         if chip_size not in (T24C32, T24C64, T24C128, T24C256, T24C512):
             print("Warning: possible unsupported chip. Size:", chip_size)
@@ -37,16 +29,8 @@ class EEPROM(BlockDevice):
         self._i2c_addr = 0  # I2C address of current chip
         self._buf1 = bytearray(1)
         self._addrbuf = bytearray(2)  # Memory offset into current chip
-        if page_size is None:
-            if chip_size not in _PAGE_SIZES:
-                raise ValueError(
-                    f'The page size for chip size {chip_size} is not known.'
-                    'Please specify it in the parameter page_size')
-            self._page_mask = ~(_PAGE_SIZES[chip_size] - 1)
-            self._page_size = _PAGE_SIZES[chip_size]
-        else:
-            self._page_mask = ~(page_size - 1)
-            self._page_size = page_size
+        self._page_size = 2 ** page_size
+        self._page_mask = ~(self._page_size - 1)
 
     # Check for a valid hardware configuration
     def scan(self, verbose, chip_size, addr, max_chips_count):


### PR DESCRIPTION
Tinkering with AT24C64 EEPROMs and the micropython_eeprom library, I noticed errors, when I ran `full_test()` in `eeprom/i2c/eep_i2c.py`.

The reason: `EEPROM._getaddr()` used a fixed page size of 128 bytes to calculate the address of the next page and the length of the data than can be written in the next write transaction.

As documented for example in Atmel/Microchip datasheets, EEPROMs with smaller capacities use smaller page sizes, down to 32 bytes (AT24C32 and AT24C64):

https://ww1.microchip.com/downloads/en/devicedoc/doc0336.pdf
https://ww1.microchip.com/downloads/en/devicedoc/doc0670.pdf

This PR fixes the problem.

Two caveats:

1. While I added page sizes for the capacities 32kBit, 64kBit, 128kBit, 256kBit, 512kBit in the dictionary _PAGE_SIZES, I can currently test the changes with AT24C64 chips. (I have though ordered a small collection of breakout boards with EEPROMs of different capacities via Aliexpress. They should be delivered in two weeks or so.)

2. I am not very familiar with the market of I2C EEPROMs, hence I am not sure if the values of default page sizes in _PAGE_SIZES really make sense. In other words: Exist for example I2C EEPROMs with 32kBit capacity that have another pages size than 32?

Reason for the change in the test module `eep_i2c.py`: I tend to upload precompiled binaries to the Micropython device, and cptest() obviously fails in its current form when the device stores *.mpy files instead of the usual *.py ones.
