### PR TITLE
Fix the page end calculation in eeprom_i2c.py for multiple chip arrays.

### DIFF
--- a/eeprom/i2c/eeprom_i2c.py
+++ b/eeprom/i2c/eeprom_i2c.py
@@ -69,7 +69,7 @@ class EEPROM(BlockDevice):
         self._addrbuf[0] = (la >> 8) & 0xFF
         self._addrbuf[1] = la & 0xFF
         self._i2c_addr = self._min_chip_address + ca
-        pe = (addr & self._page_mask) + self._page_size  # byte 0 of next page
+        pe = (la & self._page_mask) + self._page_size  # byte 0 of next page
         return min(nbytes, pe - la)
 
     # Read or write multiple bytes at an arbitrary address


### PR DESCRIPTION
This PR fixes a problem I noticed when running `eep_i2c.full_test()` with an array of two 24C64 EEPROMs: Each "read after write" check in `full_test()` failed when the EEPROM for the higher addresses was accessed.

The reason is obvious: The varuable `pe` was set by "rounding up" the full address to the next integral multiple of the page size. The `return` statement then calculates the number of bytes that fit into a page by subtracting `la`, i.e, the write start address offset within a single EEPROM, from `pe`. This leads obviously to return values (number of bytes that can be written within one EEPROM write access) that are too large.
