### PR TITLE
Fix `eep_i2c.py` for testing with smaller EEPROMs.

### DIFF
--- a/eeprom/i2c/eep_i2c.py
+++ b/eeprom/i2c/eep_i2c.py
@@ -64,6 +64,8 @@ def cp(source, dest):
 
 # ***** TEST OF DRIVER *****
 def _testblock(eep, bs):
+    if bs >= len(eep):
+        bs = len(eep) // 2
     d0 = b"this >"
     d1 = b"<is the boundary"
     d2 = d0 + d1
@@ -93,6 +95,9 @@ def _testblock(eep, bs):
 def test(eep=None):
     eep = eep if eep else get_eep()
     sa = 1000
+    address_range = 256
+    if sa + address_range > len(eep):
+        sa = (len(eep) - address_range) // 2
     for v in range(256):
         eep[sa + v] = v
     for v in range(256):
@@ -103,6 +108,8 @@ def test(eep=None):
         print("Test of byte addressing passed")
     data = uos.urandom(30)
     sa = 2000
+    if sa + len(data) > len(eep):
+        sa = (len(eep) - len(data)) // 2
     eep[sa : sa + 30] = data
     if eep[sa : sa + 30] == data:
         print("Test of slice readback passed")
@@ -126,7 +133,8 @@ def test(eep=None):
         print("Test chip boundary skipped: only one chip!")
     pe = eep.get_page_size() + 1  # One byte past page
     eep[pe] = 0xFF
-    eep[:257] = b"\0" * 257
+    write_length  = min(257, len(eep))
+    eep[:write_length] = b"\0" * write_length
     print("Test page size: ", end="")
     if eep[pe]:
         print("FAIL")


### PR DESCRIPTION
I  finally got around to build the I2C switch I mentioned in the discussion of [another pull request](https://github.com/peterhinch/micropython_eeprom/pull/23#issuecomment-1883300146).

The Kicad files are, BTW, avaliable [here](https://gitlab.com/adeuring/i2c-eeprom-test-rig)
.
This allowed me to run [somewhat more systematic tests with different EEPROMs](https://gitlab.com/adeuring/eeptest), using chips with sizes between 2 kBit and 512 kBit. The tests (i.e., the functions in `eep_i2c.py`) passed without any problems for most EEPROMs. The only exception were the smaller ones, where some address calculations yielded values outside the EEPROM size. The changes in this PR fix this problem.